### PR TITLE
Added correction for temperature sensor

### DIFF
--- a/Libraries/Arduino/src/SparkFunBME280.cpp
+++ b/Libraries/Arduino/src/SparkFunBME280.cpp
@@ -48,7 +48,8 @@ BME280::BME280( void )
 	settings.tempOverSample = 0;
 	settings.pressOverSample = 0;
 	settings.humidOverSample = 0;
-
+        // correction of temperature - added to the result
+        settings.tempCorrection = 0.0;
 }
 
 
@@ -252,7 +253,7 @@ float BME280::readTempC( void )
 	t_fine = var1 + var2;
 	float output = (t_fine * 5 + 128) >> 8;
 
-	output = output / 100;
+	output = output / 100 + settings.tempCorrection;
 	
 	return output;
 }

--- a/Libraries/Arduino/src/SparkFunBME280.h
+++ b/Libraries/Arduino/src/SparkFunBME280.h
@@ -103,6 +103,8 @@ struct SensorSettings
 	uint8_t pressOverSample;
 	uint8_t humidOverSample;
 
+    // correction of temperature - added to the result
+    float tempCorrection;
 };
 
 //Used to hold the calibration constants.  These are used


### PR DESCRIPTION
The BMP280 measures too high values - based on more sources on the internet. This fix allows to add user correction.
